### PR TITLE
feat: add body measurements view

### DIFF
--- a/src/app/tab4/tab4-routing.module.ts
+++ b/src/app/tab4/tab4-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { Tab4Page } from './tab4.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: Tab4Page,
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class Tab4PageRoutingModule {}

--- a/src/app/tab4/tab4.module.ts
+++ b/src/app/tab4/tab4.module.ts
@@ -1,0 +1,17 @@
+import { IonicModule } from '@ionic/angular';
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Tab4Page } from './tab4.page';
+import { Tab4PageRoutingModule } from './tab4-routing.module';
+
+@NgModule({
+  imports: [
+    IonicModule,
+    CommonModule,
+    FormsModule,
+    Tab4PageRoutingModule
+  ],
+  declarations: [Tab4Page]
+})
+export class Tab4PageModule {}

--- a/src/app/tab4/tab4.page.html
+++ b/src/app/tab4/tab4.page.html
@@ -1,0 +1,28 @@
+<ion-header [translucent]="true">
+  <ion-toolbar>
+    <ion-title>Medidas Corporais</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content [fullscreen]="true">
+  <div class="figures">
+    <div class="figure">
+      <img src="assets/body-front.svg" alt="Corpo frontal" />
+      <div class="label abdomen">
+        <ion-icon name="arrow-back-outline"></ion-icon>
+        <span>{{ medidas.abdomen }} cm</span>
+      </div>
+      <div class="label braco">
+        <ion-icon name="arrow-forward-outline"></ion-icon>
+        <span>{{ medidas.braco }} cm</span>
+      </div>
+    </div>
+    <div class="figure">
+      <img src="assets/body-back.svg" alt="Costas" />
+      <div class="label costas">
+        <ion-icon name="arrow-forward-outline"></ion-icon>
+        <span>{{ medidas.costas }} %</span>
+      </div>
+    </div>
+  </div>
+</ion-content>

--- a/src/app/tab4/tab4.page.scss
+++ b/src/app/tab4/tab4.page.scss
@@ -1,0 +1,43 @@
+.figures {
+  display: flex;
+  justify-content: space-around;
+  padding-top: 20px;
+}
+
+.figure {
+  position: relative;
+}
+
+.figure img {
+  width: 200px;
+  height: 400px;
+}
+
+.label {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 2px 4px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.label ion-icon {
+  margin-right: 4px;
+}
+
+.label.abdomen {
+  top: 150px;
+  left: 210px;
+}
+
+.label.braco {
+  top: 110px;
+  left: -90px;
+}
+
+.label.costas {
+  top: 150px;
+  left: -90px;
+}

--- a/src/app/tab4/tab4.page.spec.ts
+++ b/src/app/tab4/tab4.page.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+
+import { ExploreContainerComponentModule } from '../explore-container/explore-container.module';
+
+import { Tab4Page } from './tab4.page';
+
+describe('Tab4Page', () => {
+  let component: Tab4Page;
+  let fixture: ComponentFixture<Tab4Page>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [Tab4Page],
+      imports: [IonicModule.forRoot(), ExploreContainerComponentModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Tab4Page);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/tab4/tab4.page.ts
+++ b/src/app/tab4/tab4.page.ts
@@ -1,0 +1,30 @@
+import { Component } from '@angular/core';
+
+interface MedidasCorporais {
+  abdomen: number;
+  braco: number;
+  costas: number;
+}
+
+@Component({
+  selector: 'app-tab4',
+  templateUrl: 'tab4.page.html',
+  styleUrls: ['tab4.page.scss'],
+  standalone: false,
+})
+export class Tab4Page {
+  medidas: MedidasCorporais = {
+    abdomen: 0,
+    braco: 0,
+    costas: 0,
+  };
+
+  constructor() {
+    // Valores de exemplo; em uma aplicação real os dados viriam de um serviço
+    this.medidas = {
+      abdomen: 80,
+      braco: 30,
+      costas: 25,
+    };
+  }
+}

--- a/src/app/tabs/tabs-routing.module.ts
+++ b/src/app/tabs/tabs-routing.module.ts
@@ -20,6 +20,10 @@ const routes: Routes = [
         loadChildren: () => import('../tab3/tab3.module').then(m => m.Tab3PageModule)
       },
       {
+        path: 'tab4',
+        loadChildren: () => import('../tab4/tab4.module').then(m => m.Tab4PageModule)
+      },
+      {
         path: '',
         redirectTo: '/tabs/tab1',
         pathMatch: 'full'

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -15,6 +15,11 @@
       <ion-icon aria-hidden="true" name="nutrition"></ion-icon>
       <ion-label>Dieta</ion-label>
     </ion-tab-button>
+
+    <ion-tab-button tab="tab4" href="/tabs/tab4">
+      <ion-icon name="body-outline"></ion-icon>
+      <ion-label>Medidas</ion-label>
+    </ion-tab-button>
   </ion-tab-bar>
 
 </ion-tabs>

--- a/src/assets/body-back.svg
+++ b/src/assets/body-back.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 200 400" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="100" cy="40" r="30" fill="#c0c0c0"/>
+  <rect x="70" y="70" width="60" height="120" fill="#c0c0c0"/>
+  <rect x="40" y="80" width="30" height="100" fill="#c0c0c0"/>
+  <rect x="130" y="80" width="30" height="100" fill="#c0c0c0"/>
+  <rect x="70" y="190" width="30" height="120" fill="#c0c0c0"/>
+  <rect x="100" y="190" width="30" height="120" fill="#c0c0c0"/>
+</svg>

--- a/src/assets/body-front.svg
+++ b/src/assets/body-front.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 200 400" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="100" cy="40" r="30" fill="#d0d0d0"/>
+  <rect x="70" y="70" width="60" height="120" fill="#d0d0d0"/>
+  <rect x="40" y="80" width="30" height="100" fill="#d0d0d0"/>
+  <rect x="130" y="80" width="30" height="100" fill="#d0d0d0"/>
+  <rect x="70" y="190" width="30" height="120" fill="#d0d0d0"/>
+  <rect x="100" y="190" width="30" height="120" fill="#d0d0d0"/>
+</svg>


### PR DESCRIPTION
## Summary
- add new Medidas tab with human body diagrams
- allow patients to see abdomen, arm and back values
- provide sample body measurement interface

## Testing
- `npm run lint` *(fails: Lifecycle methods should not be empty)*
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689612e48a148333a8f0bee5dccc5b5b